### PR TITLE
Fix code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/dropship_project_backup/main_app/views.py
+++ b/dropship_project_backup/main_app/views.py
@@ -128,4 +128,7 @@ def post_product(request):
             response = post_product_with_forecasting(api_key, product_details)
             return JsonResponse(response, status=200)
         except Exception as e:
-            return JsonResponse({"error": str(e)}, status=400)
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.error("Error in post_product: %s", str(e))
+            return JsonResponse({"error": "An internal error has occurred."}, status=400)


### PR DESCRIPTION
Fixes [https://github.com/CrzyHAX91/FastNLexpress/security/code-scanning/10](https://github.com/CrzyHAX91/FastNLexpress/security/code-scanning/10)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

- Modify the exception handling block to log the detailed error message using Django's logging framework.
- Return a generic error message to the user to avoid exposing sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent the exposure of detailed exception messages to the end user.