### PR TITLE
Update django.yml

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,34 +1,51 @@
-name: Python CI
+name: Django CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.10, 3.11]
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
       with:
-        python-version: '3.10'  # Use a supported version
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache Python packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ runner.arch }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ runner.arch }}-
+          ${{ runner.os }}-pip-
 
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Run Django Migrations
+      run: |
+        python manage.py migrate
+
     - name: Run Tests
       run: |
-        python -m unittest discover
+        python manage.py test
 
     - name: Check Code Style
       run: |
         pip install flake8
-        flake8 .
+        flake8 

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary by Sourcery

Update CI pipeline to use Python 3.10 and 3.11, cache dependencies, run migrations before tests, and lint with flake8.

CI:
- Switch the target branch from "main" to "master".
- Add dependency caching to speed up the workflow.
- Run database migrations before running tests.
- Update Python versions to 3.10 and 3.11.
- Use flake8 for code style checking instead of running unit tests with unittest discover.