### PR TITLE
Update actions/checkout to v4 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set up Python
       - name: Set up Python ${{ matrix.python-version }}
@@ -70,7 +70,3 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
           verbose: true
-
-
-
-      

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v3

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set Up Qodana Cache
       id: cache

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Follow the instructions in the `SETUP.md` file to set up the development environ
 
 ## Contributing
 
-We welcome contributions! Please refer to the `CONTRIBUTING.md` file for guidelines.
-
+We welcome contributions! Please refer to the `CONTRIBUTING.md` file for guidelines. Ensure you are using `actions/checkout@v4` in your workflows.
 ## License
 
 This project is licensed under the MIT License.


### PR DESCRIPTION
Related to #47

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CrzyHAX91/FastNLexpress/pull/48?shareId=fdc2cd0f-597b-4a0e-b8f9-0a062752a5ff).

## Summary by Sourcery

Update GitHub Actions workflows to use actions/checkout@v4.

CI:
- Update all workflows to use actions/checkout@v4.

Documentation:
- Update contributing guidelines to reflect the change to actions/checkout@v4.